### PR TITLE
Play 2.5 version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /project/project/
 target/
+.idea

--- a/README.md
+++ b/README.md
@@ -4,10 +4,15 @@ This plugin allows you to use [Logback](http://logback.qos.ch)'s very flexible [
 
 ## Installation
 
+Add the following dependency for Play 2.5.x:
+
+    libraryDependencies += "org.databrary" %% "play-logback-access" % "0.5"
+
+### Play 2.4.x
+
 Add the following dependency for Play 2.4.x:
 
     libraryDependencies += "org.databrary" %% "play-logback-access" % "0.4"
-
 
 ### Play 2.3.x
 
@@ -55,10 +60,25 @@ There is also a `logbackaccess.context` setting if you want it to use an [execut
 The library will automatically initialize itself as a [Play Module](https://www.playframework.com/documentation/2.4.x/Modules).
 
 Inject `PlayLogbackAccessApi` into any class to gain access to the API. This exposes:
-- `filter` - [Play Filter](https://www.playframework.com/documentation/2.4.x/ScalaHttpFilters) to log requests automatically
 - `log(requestTime: Long, request: RequestHeader, result: Result, user: Option[String])` - Manually log to the Access logger
+Inject `PlayLogbackAccessFilter` to access a Filter (in 0.4 and earlier this was available as `filter` on the above)
 
 ### Example: Filter
+
+#### 0.5 and later:
+
+In file: `app/Filters.scala`
+```scala
+import javax.inject.Inject
+import org.databrary.PlayLogbackAccessFilter
+import play.api.http.HttpFilters
+
+class Filters @Inject() (accessLogger: PlayLogbackAccessFilter) extends HttpFilters {
+  val filters = Seq(accessLogger)
+}
+```
+
+#### Before 0.5:
 
 In file: `app/Filters.scala`
 ```scala

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The library will automatically initialize itself as a [Play Module](https://www.
 
 Inject `PlayLogbackAccessApi` into any class to gain access to the API. This exposes:
 - `log(requestTime: Long, request: RequestHeader, result: Result, user: Option[String])` - Manually log to the Access logger
+
 Inject `PlayLogbackAccessFilter` to access a Filter (in 0.4 and earlier this was available as `filter` on the above)
 
 ### Example: Filter

--- a/build.sbt
+++ b/build.sbt
@@ -8,19 +8,23 @@ homepage := Some(url("http://github.com/databrary/play-logback-access"))
 
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-version := "0.4"
+version := "0.5"
 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play" % "2.4.3",
+  "com.typesafe.play" %% "play" % "2.5.0",
   "ch.qos.logback" % "logback-access" % "1.1.3",
   "javax.servlet" % "servlet-api" % "2.5"
 )
 
+libraryDependencies ++= Seq(
+  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.0" % Test
+)
+
 scalaVersion := "2.11.7"
 
-crossScalaVersions ++= Seq("2.10.4")
+//crossScalaVersions ++= Seq("2.10.4")
 
 scalacOptions ++= Seq("-feature","-deprecation")
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % "2.5.0",
-  "ch.qos.logback" % "logback-access" % "1.1.3",
+  "ch.qos.logback" % "logback-access" % "1.1.4",
   "javax.servlet" % "servlet-api" % "2.5"
 )
 

--- a/src/main/scala/module.scala
+++ b/src/main/scala/module.scala
@@ -2,38 +2,59 @@ package org.databrary
 
 import java.io.File
 import java.net.URL
-import javax.inject.Inject
+import javax.inject.{Inject, Provider, Singleton}
+
+import akka.actor.ActorSystem
+import akka.stream.Materializer
 import play.api.inject.{ApplicationLifecycle, Binding, Module}
 import play.api.libs.concurrent
-import play.api.mvc.{Filter, Result, RequestHeader}
-import play.api.{Configuration, Environment}
+import play.api.mvc.{Filter, RequestHeader, Result}
+import play.api.{Application, Configuration, Environment}
+
 import scala.concurrent.Future
 
 trait PlayLogbackAccessApi {
   val context: PlayLogbackAccess
   def log(requestTime : Long = -1, request : RequestHeader, result : Result, user : Option[String] = None)
-  val filter: Filter
+}
+
+trait PlayLogbackAccessFilter extends Filter
+
+/** A Filter that can be used to automatically log all requests. */
+@Singleton
+class PlayLogbackAccessFilterImpl @Inject()(
+    val mat: Materializer,
+    configuration: Configuration,
+    actorSystem: ActorSystem,
+    apiProvider: Provider[PlayLogbackAccessApi]) extends PlayLogbackAccessFilter {
+
+  private[this] implicit lazy val executionContext = configuration.getString("logbackaccess.context")
+    .fold(concurrent.Execution.defaultContext)(
+      actorSystem.dispatchers.lookup)
+
+  private lazy val provider = apiProvider.get
+
+  def apply(next : RequestHeader => Future[Result])(req : RequestHeader) : Future[Result] = {
+    val rt = System.currentTimeMillis
+    val res = next(req)
+    res.onSuccess { case res : Result =>
+      provider.log(rt, req, res)
+    }
+    res
+  }
 }
 
 class PlayLogbackAccessApiImpl @Inject() (app: play.api.Application, lifecycle: ApplicationLifecycle) extends PlayLogbackAccessApi {
 
-  private[this] lazy val executionContext = app.configuration.getString("logbackaccess.context")
-    .fold(concurrent.Execution.defaultContext)(
-      concurrent.Akka.system(app).dispatchers.lookup)
-
   private[this] lazy val configs =
     app.configuration.getString("logbackaccess.config.file").map(new File(_).toURI.toURL) ++
-      app.configuration.getString("logbackaccess.config.resource").flatMap(app.resource(_)) ++
+      app.configuration.getString("logbackaccess.config.resource").flatMap(app.resource) ++
       app.configuration.getString("logbackaccess.config.url").map(new URL(_))
 
-  lazy val context = new PlayLogbackAccess(configs)(executionContext)
+  lazy val context = new PlayLogbackAccess(configs)
 
   override def log(requestTime: Long, request: RequestHeader, result: Result, user: Option[String]): Unit =
     context.log _
-
-  override val filter: Filter =
-    context.filter
-
 
   context.start()
 
@@ -44,6 +65,7 @@ class PlayLogbackAccessApiImpl @Inject() (app: play.api.Application, lifecycle: 
 
 class PlayLogbackAccessModule extends Module {
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
-    bind[PlayLogbackAccessApi].to[PlayLogbackAccessApiImpl].eagerly()
+    bind[PlayLogbackAccessApi].to[PlayLogbackAccessApiImpl].eagerly(),
+    bind[PlayLogbackAccessFilter].to[PlayLogbackAccessFilterImpl]
   )
 }

--- a/src/main/scala/module.scala
+++ b/src/main/scala/module.scala
@@ -32,13 +32,13 @@ class PlayLogbackAccessFilterImpl @Inject()(
     .fold(concurrent.Execution.defaultContext)(
       actorSystem.dispatchers.lookup)
 
-  private lazy val provider = apiProvider.get
+  private lazy val api = apiProvider.get
 
   def apply(next : RequestHeader => Future[Result])(req : RequestHeader) : Future[Result] = {
     val rt = System.currentTimeMillis
     val res = next(req)
     res.onSuccess { case res : Result =>
-      provider.log(rt, req, res)
+      api.log(rt, req, res)
     }
     res
   }

--- a/src/main/scala/plugin.scala
+++ b/src/main/scala/plugin.scala
@@ -2,22 +2,22 @@ package org.databrary
 
 import java.io.File
 import java.net.URL
-import javax.inject.Inject
-import scala.concurrent.{ExecutionContext,Future}
-import play.api.Plugin
-import play.api.libs.concurrent
-import play.api.mvc.{RequestHeader,Result,Filter}
+
+import akka.stream.Materializer
 import ch.qos.logback.access.joran.JoranConfigurator
 import ch.qos.logback.access.spi.IAccessEvent
-import ch.qos.logback.{core => Logback}
 import ch.qos.logback.core.spi._
+import ch.qos.logback.{core => Logback}
+import play.api.mvc.{RequestHeader, Result}
+
+import scala.concurrent.ExecutionContext
 
 object PlayLogbackAccess {
   final val defaultConfigFile = new File("conf", "logback-access.xml")
 }
 
-final class PlayLogbackAccess(configs : Iterable[URL])(implicit executionContext : ExecutionContext) extends
-  Logback.ContextBase with AppenderAttachable[IAccessEvent] with FilterAttachable[IAccessEvent] {
+final class PlayLogbackAccess(configs : Iterable[URL])
+  extends Logback.ContextBase with AppenderAttachable[IAccessEvent] with FilterAttachable[IAccessEvent] {
 
   private[this] val aai = new AppenderAttachableImpl[IAccessEvent]
   private[this] val fai = new FilterAttachableImpl[IAccessEvent]
@@ -43,18 +43,6 @@ final class PlayLogbackAccess(configs : Iterable[URL])(implicit executionContext
       aai.appendLoopOnAppenders(ev)
   }
 
-  /** A Filter that can be used to automatically log all requests. */
-  object filter extends Filter {
-    def apply(next : RequestHeader => Future[Result])(req : RequestHeader) : Future[Result] = {
-      val rt = System.currentTimeMillis
-      val res = next(req)
-      res.onSuccess { case res : Result =>
-	log(rt, req, res)
-      }
-      res
-    }
-  }
-
   def detachAndStopAllAppenders = aai.detachAndStopAllAppenders
   def getAppender(a : String) = aai.getAppender(a)
   def isAttached(a : Logback.Appender[IAccessEvent]) = aai.isAttached(a)
@@ -67,19 +55,4 @@ final class PlayLogbackAccess(configs : Iterable[URL])(implicit executionContext
   def getCopyOfAttachedFiltersList = fai.getCopyOfAttachedFiltersList
   def addFilter(f : Logback.filter.Filter[IAccessEvent]) = fai.addFilter(f)
   def getFilterChainDecision(e : IAccessEvent) = fai.getFilterChainDecision(e)
-}
-
-final class LogbackAccessPlugin @Inject() (implicit app : play.api.Application) extends Plugin {
-  private[this] lazy val executionContext = app.configuration.getString("logbackaccess.context")
-    .fold(concurrent.Execution.defaultContext)(
-      concurrent.Akka.system(app).dispatchers.lookup)
-  private[this] lazy val configs =
-    app.configuration.getString("logbackaccess.config.file").map(new File(_).toURI.toURL) ++
-    app.configuration.getString("logbackaccess.config.resource").flatMap(app.resource(_)) ++
-    app.configuration.getString("logbackaccess.config.url").map(new URL(_))
-
-  lazy val api = new PlayLogbackAccess(configs)(executionContext)
-
-  override def onStart = api.start
-  override def onStop = api.stop
 }

--- a/src/test/scala/Filters.scala
+++ b/src/test/scala/Filters.scala
@@ -1,0 +1,12 @@
+import javax.inject.Inject
+
+import org.databrary.PlayLogbackAccessFilter
+import play.api.http.HttpFilters
+import play.api.mvc.EssentialFilter
+
+/**
+  * `Filters` class in the root package is loaded automatically by Play.
+  */
+class Filters @Inject() (logback: PlayLogbackAccessFilter) extends HttpFilters {
+  override def filters: Seq[EssentialFilter] = Seq(logback)
+}

--- a/src/test/scala/ModuleSpec.scala
+++ b/src/test/scala/ModuleSpec.scala
@@ -1,0 +1,18 @@
+
+import org.databrary.{PlayLogbackAccessApi, PlayLogbackAccessFilter}
+import org.scalatestplus.play._
+import play.api.test.FakeApplication
+
+class ModuleSpec extends PlaySpec {
+  "PlayLogbackAccessModule" should {
+    "load successfully" in {
+      // Simply checking that Guice doesn't run into any
+      // cyclic dependency errors.
+      val app = FakeApplication()
+      val api = app.injector.instanceOf[PlayLogbackAccessApi]
+      val filter = app.injector.instanceOf[PlayLogbackAccessFilter]
+      api must not be null
+      filter must not be null
+    }
+  }
+}


### PR DESCRIPTION
The main change I had to make was to pull the Filter out of the API and into its own Guice binding, because it was causing cyclic dependency errors that I couldn't resolve any other way (Api required Application which required Filters which required Api...). Some lazy vals allow the Filter to be created after the Api.

Let me know if it'd be better with a different version (have gone with 0.5) or merging to an alternate branch.
