### PR TITLE
Pass arguments through to PlayLogbackAccess.log

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % "2.5.0",
   "ch.qos.logback" % "logback-access" % "1.1.4",
-  "javax.servlet" % "servlet-api" % "2.5"
+  "javax.servlet" % "servlet-api" % "2.5" % Optional
 )
 
 libraryDependencies ++= Seq(

--- a/src/main/scala/module.scala
+++ b/src/main/scala/module.scala
@@ -9,7 +9,7 @@ import akka.stream.Materializer
 import play.api.inject.{ApplicationLifecycle, Binding, Module}
 import play.api.libs.concurrent
 import play.api.mvc.{Filter, RequestHeader, Result}
-import play.api.{Application, Configuration, Environment}
+import play.api.{Configuration, Environment}
 
 import scala.concurrent.Future
 
@@ -54,7 +54,7 @@ class PlayLogbackAccessApiImpl @Inject() (app: play.api.Application, lifecycle: 
   lazy val context = new PlayLogbackAccess(configs)
 
   override def log(requestTime: Long, request: RequestHeader, result: Result, user: Option[String]): Unit =
-    context.log _
+    context.log(requestTime, request, result, user)
 
   context.start()
 


### PR DESCRIPTION
This fixes #6. In addition, the `javax.servlet:servlet-api` dependency is made optional, since it is an unnecessary (and unwanted) transitive dependency for Play applications that are not run in a Servlet environment.
