### PR TITLE
Fix issues caused by eager inject and `reference.conf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For older versions of Play use:
 Add a configuration file to your `conf/application.conf` with something like:
 
     logbackaccess.config.resource=logback-access.xml
+    play.modules.enabled += "org.databrary.PlayLogbackAccessModule"
 
 Then in `conf/logback-access.xml`:
 
@@ -53,7 +54,12 @@ There is also a `logbackaccess.context` setting if you want it to use an [execut
 
 ## Usage
 
-The library will automatically initialize itself as a [Play Module](https://www.playframework.com/documentation/2.4.x/Modules).
+The library is a [Play Module](https://www.playframework.com/documentation/2.5.x/Modules) which
+you need to enable by adding this to application's `.conf` file:
+
+    play.modules.enabled += "org.databrary.PlayLogbackAccessModule"
+
+(if you experience any issues with dependency injection (esp. during tests), please try using `PlayLogbackAccessLazyInjectModule` which does the lazy dependency injection)
 
 Inject `PlayLogbackAccessApi` into any class to gain access to the API. This exposes:
 - `log(requestTime: Long, request: RequestHeader, result: Result, user: Option[String])` - Manually log to the Access logger

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,1 +1,2 @@
-play.modules.enabled += "org.databrary.PlayLogbackAccessModule"
+// to be enabled by the user
+// play.modules.enabled += "org.databrary.PlayLogbackAccessModule"

--- a/src/main/scala/module.scala
+++ b/src/main/scala/module.scala
@@ -69,3 +69,10 @@ class PlayLogbackAccessModule extends Module {
     bind[PlayLogbackAccessFilter].to[PlayLogbackAccessFilterImpl]
   )
 }
+
+class PlayLogbackAccessLazyInjectModule extends Module {
+  override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
+    bind[PlayLogbackAccessApi].to[PlayLogbackAccessApiImpl],
+    bind[PlayLogbackAccessFilter].to[PlayLogbackAccessFilterImpl]
+  )
+}


### PR DESCRIPTION
changes:
---

- add a lazy DI version of the `PlayLogbackAccessModule`
- user need to explicitly add `play.modules.enabled += "org.databrary.PlayLogbackAccessModule"` 

please publish a fix for 0.5.x (play 2.5.x) version too to binTray. 
working branch here https://github.com/vidma/play-logback-access/tree/fix/eager-inject-issues-in-tests-etc

description/notes:
---

- eager loading of a module from `reference.conf` is not necessarily a good idea. Because it  [requires a `play.api.Application` to be injected](https://github.com/cardamo/play-logback-access/blob/4da3d5dd02e3e4a8e77a7c180c18d1f47e9e0ea5/src/main/scala/module.scala#L47)! Consider `sbt test` , the module would still get loaded, but there might be no configured Application, or it might be invalid to load the Application in this way or at this time.
   * e.g. when `CacheApi` is injected into a controller, tests fail due to DI failure - multiple instances of play cache get initialized -> failure.
-  loading this module from `reference.conf`  which can't be overridden/modified, it's too much confusing & limiting the user (e.g. impossible to disable in tests).
    * I wasted multiple hours to find out DI issues were actually cased by this module being secretly loaded