### PR TITLE
Updated PlayAccessEvent to return the contentlength when available...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /project/project/
 target/
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -12,20 +12,20 @@ homepage := Some(url("http://github.com/cardamo/play-logback-access"))
 
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-version := "0.6.2"
+version := "0.6.2a"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play" % "2.6.0",
+  "com.typesafe.play" %% "play" % "2.6.18",
   "ch.qos.logback" % "logback-access" % "1.2.3",
   "javax.servlet" % "javax.servlet-api" % "3.1.0" % Optional
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "3.0.0" % Test
+  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test
 )
 
-scalaVersion := "2.12.2"
-crossScalaVersions := Seq("2.11.7", "2.12.2")
+scalaVersion := "2.12.6"
+crossScalaVersions := Seq("2.11.12", scalaVersion.value)
 
 scalacOptions ++= Seq("-feature","-deprecation")
 

--- a/src/main/scala/adapter.scala
+++ b/src/main/scala/adapter.scala
@@ -52,7 +52,7 @@ final case class PlayAccessEvent(requestTime : Long, request : RequestHeader, re
   def getAttribute(key : String) = IAccessEvent.NA
   def getRequestParameter(key : String) = request.queryString.get(key).fold(Array(IAccessEvent.NA))(_.toArray)
   def getCookie(key : String) = request.cookies.get(key).fold(IAccessEvent.NA)(_.value)
-  def getContentLength = IAccessEvent.SENTINEL // no way to get this here
+  def getContentLength = result.body.contentLength.getOrElse(IAccessEvent.SENTINEL)
   def getStatusCode = result.header.status
   /* these could be implemented for full logging, but may be too costly: */
   def getRequestContent = ""


### PR DESCRIPTION
… instead of always returning -1. Depending on the used HttpEntity the content length is probably available most of the times.
Don't understand why this was not added in the first place. Any particular reason for that?

Updated some dependencies and Scala versions.
Added Idea configs to ignore file.